### PR TITLE
Remote interface changes, one setting made runtime.

### DIFF
--- a/factory-levels/changelog.txt
+++ b/factory-levels/changelog.txt
@@ -1,3 +1,9 @@
+Version: ???
+  - Thanks to CaitSith2: Added remote interface command update_machine
+  - Thanks to CaitSith2: Added remote interface command remove_machine
+  - Thanks to CaitSith2: Added remote interface command get_machine
+  - Thanks to CaitSith2: Machine level exponent is now a map setting.
+-------------------------------------------------------
 Version: 0.4.2
   - Space Exploration did not work with assembler productivity, now it does
 -------------------------------------------------------
@@ -24,7 +30,7 @@ Version: 0.2.3
   - Fix bug: Levels of entities could exceed max level for entity
 -------------------------------------------------------
 Version: 0.2.2
-  - fix bug
+  - fix bug: Stone furnace levels 1-25 and steel furnace levels 1-100 were unable to smelt stone into bricks in space exploration
 -------------------------------------------------------
 Version: 0.2.1
   - Buildings now start with proper level on constructon if stored levels allow for it

--- a/factory-levels/settings.lua
+++ b/factory-levels/settings.lua
@@ -39,7 +39,7 @@ data:extend({
         name = "factory-levels-exponent",
         order = "e",
         minimum_value = 1.5, maximum_value = 5,
-        setting_type = "startup",
+        setting_type = "runtime-global",
         default_value = 3
     }
 })


### PR DESCRIPTION
Added remote inteface command update_machine, takes same parameter set as add_machine, but the only one that is mandatory is the name.
Added remote interface command remove_machine,  specifies a machine to remove the machine table by name.
Add remote interface command get_machine.  Returns the machine entry definition from the machine table, specified by name.

Machine exponent for crafting is now a map runtime setting.  If the levels exist, it reports how many crafts for levels 25, 50, and 100,  as well as the crafts for max level if it is not 100.

No idea what version number you are going to assign to the mod, but I updated the changelog to match with the changes.  Also noted what the actual bug fix for 0.2.2 was in the change log.