### PR TITLE
Changes

### DIFF
--- a/factory-levels/changelog.txt
+++ b/factory-levels/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.6.8
+Date: 2022-09-24
+  Changes:
+    - Thanks to CaitSith2: mods via remote interface can now declare they wish to be disabled.
+    - Thanks to CaitSith2: machines no longer instantly level up to the next tier the moment they hit max level of current tier.
+  Bugfix:
+    - Thanks to CaitSith2: fixed a bug with on_configuration_changed. (this event fires on updating any mods, or installing/removing any mods.)
+---------------------------------------------------------------------------------------------------
 Version: 0.6.7
 Date: 2022-09-07
   Bugfix:

--- a/factory-levels/control.lua
+++ b/factory-levels/control.lua
@@ -15,7 +15,7 @@ function get_built_machines()
 	for unit_number, machine in pairs(global.built_machines) do
 		-- Remove invalid machines from the global table.
 		if not machine.entity or not machine.entity.valid then
-			global.built_machines[index] = nil
+			global.built_machines[unit_number] = nil
 		end
 	end
 	local built_assemblers = {}

--- a/factory-levels/control.lua
+++ b/factory-levels/control.lua
@@ -186,7 +186,7 @@ function update_machine_levels(overwrite)
 			end
 		end
 	end
-	for i = 1, max_level, 1 do
+	for i = 1, (max_level + 1), 1 do -- Adding one more level for machine upgrade to next tier.
 		if required_items_for_levels[i] == nil then
 			table.insert(required_items_for_levels, math.floor(1 + math.pow(i, exponent)))
 		end
@@ -389,7 +389,7 @@ function replace_machines(entities)
 				elseif (should_have_level > current_level and current_level < machine.max_level) then
 					upgrade_factory(entity.surface, machine.level_name .. math.min(should_have_level, machine.max_level), entity)
 					break
-				elseif (current_level == machine.max_level and machine.next_machine ~= nil) then
+				elseif (should_have_level > current_level and current_level >= machine.max_level and machine.next_machine ~= nil) then
 					local created = upgrade_factory(entity.surface, machine.next_machine, entity)
 					created.products_finished = 0
 					break

--- a/factory-levels/control.lua
+++ b/factory-levels/control.lua
@@ -213,6 +213,7 @@ remote.add_interface("factory_levels", {
 			machines[machine.name].level_name = machine.level_name or machines[machine.name].level_name
 			machines[machine.name].max_level = machine.max_level or machines[machine.name].max_level
 			machines[machine.name].next_machine = machine.next_machine or machines[machine.name].next_machine
+			machines[machine.name].disable_mod_setting = machine.disable_mod_setting or machines[machine.name].disable_mod_setting
 			if machines[machine.name].max_level > max_level then
 				max_level = machines[machine.name].max_level
 				update_machine_levels()
@@ -375,12 +376,14 @@ function replace_machines(entities)
 		for _, machine in pairs(machines) do
 			if (entity.name == machine.name and entity.products_finished > 0) then
 				if not settings.global["factory-levels-disable-mod"].value then
-					upgrade_factory(entity.surface, machine.level_name .. math.min(should_have_level, machine.max_level), entity)
+					if not machine.disable_mod_setting or not settings.global[machine.disable_mod_setting].value then
+						upgrade_factory(entity.surface, machine.level_name .. math.min(should_have_level, machine.max_level), entity)
+					end
 				end
 				break
 			elseif string_starts_with(entity.name, machine.level_name) then
 				local current_level = tonumber(string.match(entity.name, "%d+$"))
-				if (settings.global["factory-levels-disable-mod"].value) then
+				if (settings.global["factory-levels-disable-mod"].value) or (machine.disable_mod_setting and settings.global[machine.disable_mod_setting].value) then
 					upgrade_factory(entity.surface, machine.name, entity)
 					break
 				elseif (should_have_level > current_level and current_level < machine.max_level) then

--- a/factory-levels/info.json
+++ b/factory-levels/info.json
@@ -1,7 +1,7 @@
 {
   "name": "factory-levels",
   "title": "Factory Levels",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "author": "sensenmann",
   "homepage": "https://github.com/renoth/factorio-factory-levels",
   "description": "Factories can level up by producing items",

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.renoth</groupId>
     <artifactId>factory-levels</artifactId>
-    <version>0.6.7</version>
+    <version>0.6.8</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
* Fix a crash bug in the on_configuration_changed event.
* Machines no longer upgrade to next tier ASAP once the current tier max level is reached.  There is one more level worth of crafts required for next tier.
* Mods via remote interface can now declare that they wish to have their factory-levels portion disabled, either for safe removal of the mod in case of the mod being a shim, or otherwise user doesn't wish to have factory levels applied to the mod adding support to it.